### PR TITLE
Rename method

### DIFF
--- a/lib/spicy_validation/monkey/new_hash_syntax.rb
+++ b/lib/spicy_validation/monkey/new_hash_syntax.rb
@@ -2,7 +2,7 @@
 
 module NewHashSyntax
   refine Hash do
-    def format
+    def format_hash
       map { |k, v| "#{k}: #{v.inspect}" }.join(", ")
     end
   end

--- a/lib/spicy_validation/validation.rb
+++ b/lib/spicy_validation/validation.rb
@@ -41,7 +41,7 @@ module SpicyValidation
       if options.blank?
         "#{method_name} #{column_name.inspect}"
       else
-        "#{method_name} #{column_name.inspect}, #{options.format}"
+        "#{method_name} #{column_name.inspect}, #{options.format_hash}"
       end
     end
   end


### PR DESCRIPTION
## Overview

- rename `format` method to `format_hash` method because `format` method is already defined in Ruby.